### PR TITLE
Fixed Publishing Artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
                 default: << pipeline.git.tag >>
                 type: string
         docker:
-            - image: kohirens/go-release:1.22.3
+            - image: kohirens/go-release:1.22
               auth:
                   username: ${DH_USER}
                   password: ${DH_PASS}


### PR DESCRIPTION
CI configuration was referring to a non-existant go-release image. This was verfied and fixed.