### PR TITLE
Fixed Validating Manifest With No Path

### DIFF
--- a/internal/msg/stderr.go
+++ b/internal/msg/stderr.go
@@ -29,12 +29,12 @@ var Stderr = struct {
 	GetRemoteTags          string
 	InvalidCmd             string
 	InvalidManifest        string
-	InvalidManifestVersion string
 	InvalidNoArgs          string
 	InvalidNoSubCmdArgs    string
 	InvalidPlaceholderName string
 	InvalidRegExp          string
 	InvalidTmplDir         string
+	ManifestValidation     string
 	MissingTmplJson        string
 	MissingTmplJsonVersion string
 	NewManifest            string
@@ -48,6 +48,7 @@ var Stderr = struct {
 	ParseGenerateInput     string
 	ParseInt               string
 	ParseUInt              string
+	ParseValidateInput     string
 	ParsingConfigArgs      string
 	PathNotAllowed         string
 	PlaceholdersProperty   string
@@ -84,12 +85,12 @@ var Stderr = struct {
 	GetLatestTag:           "failed to get latest tag from %v: %v",
 	InvalidCmd:             "invalid command %v",
 	InvalidManifest:        "invalid manifest found at %v, will replace it with the default",
-	InvalidManifestVersion: "bad manifest version %v, current version is %v",
 	InvalidNoArgs:          "invalid number of arguments passed to the config command, please see config -help for usage",
 	InvalidNoSubCmdArgs:    "subcommand %v takes at least %v arguments, run \"%[1]s -h\" for usage details",
 	InvalidPlaceholderName: "invalid placeholder name %v",
 	InvalidRegExp:          "invalid regular expression %q, %v",
 	InvalidTmplDir:         "invalid template directory %q",
+	ManifestValidation:     "problem with manifest %v, %v",
 	MissingTmplJson:        "%s is a file that is required to be in the template, there was a problem reading %q; error %q",
 	MissingTmplJsonVersion: "missing the Version property in template.json",
 	NewManifest:            "could not initialize a new manifest, %v",
@@ -103,6 +104,7 @@ var Stderr = struct {
 	ParseGenerateInput:     "could not parse generate input: %v",
 	ParseInt:               "could not parse %v as a integer, %v",
 	ParseUInt:              "could not parse %v as a natural number, %v",
+	ParseValidateInput:     "could not parse validate input: %v",
 	ParsingConfigArgs:      "error parsing config command args: %v",
 	PathNotAllowed:         "path/URL to template is not in the allow-list",
 	PlaceholdersProperty:   "bad placeholders variables %v, %v",

--- a/internal/press/validation.go
+++ b/internal/press/validation.go
@@ -5,7 +5,6 @@ import (
 	"github.com/kohirens/stdlib/fsio"
 	"github.com/kohirens/stdlib/log"
 	"github.com/kohirens/tmplpress/internal/msg"
-	"golang.org/x/mod/semver"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -50,7 +49,7 @@ func ValidateManifest(aFile string) error {
 	}
 
 	if e := checkValidationRules(tm.Placeholders, tm.Validation); e != nil {
-		return fmt.Errorf(msg.Stderr.CannotReadFile, aFile, e.Error())
+		return fmt.Errorf(msg.Stderr.ManifestValidation, aFile, e.Error())
 	}
 
 	return nil
@@ -141,20 +140,6 @@ func checkVarName(vars map[string]string) error {
 			return fmt.Errorf(msg.Stderr.InvalidPlaceholderName, name)
 		}
 	}
-	return nil
-}
-
-func checkVersion(semantic string) error {
-	ver := "v" + semantic
-	if !semver.IsValid(ver) {
-		return fmt.Errorf(msg.Stderr.MissingTmplJsonVersion)
-	}
-
-	c := semver.Compare(ver, "v"+schemaVersion)
-	if c == 1 {
-		return fmt.Errorf(msg.Stderr.InvalidManifestVersion, semantic)
-	}
-
 	return nil
 }
 

--- a/subcommand/manifest/manifest_test.go
+++ b/subcommand/manifest/manifest_test.go
@@ -39,7 +39,7 @@ func TestGenerateATemplateJson(runner *testing.T) {
 	for _, tc := range testCases {
 		runner.Run(tc.name, func(t *testing.T) {
 			repoPath := git.CloneFromBundle(tc.repo, tmpDir, fixtureDir, ps)
-			got, err := generateATemplateManifest(Arguments{Path: repoPath})
+			got, err := generateATemplateManifest(repoPath, "")
 			if err != nil {
 				t.Errorf("want nil, got: %q", err.Error())
 			}


### PR DESCRIPTION
When you do not pass the path to the manifest as the first argument, the program threw an error. This will default to the current working directory when no path is given.