### PR TITLE
CI Upgrade Version Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,17 +155,7 @@ workflows:
                   filters:
                       <<: *filter-semantic-tag
                   dockerfile: ".docker/Dockerfile"
-                  image_tag: "<< pipeline.git.tag >>"
-                  repository: "kohirens/<< pipeline.parameters.app_name >>"
-                  do_attach_workspace: true
-                  do_checkout: false
-                  requires: [ co ]
-            - vr/publish-docker-hub:
-                  context: << pipeline.parameters.ctx_docker_hub >>
-                  filters:
-                      <<: *filter-semantic-tag
-                  dockerfile: ".docker/Dockerfile"
-                  image_tag: "latest"
+                  image_tag: "<< pipeline.git.tag >> latest"
                   repository: "kohirens/<< pipeline.parameters.app_name >>"
                   do_attach_workspace: true
                   do_checkout: false


### PR DESCRIPTION
Upgraded CI version release tool to combine the publish image job into
1. The latest release allows you to tag the same image with multiple tags without duplicating the job to achieve the same effect.